### PR TITLE
Refactor the collision detection function to avoid expensive sqrt operations

### DIFF
--- a/src/Reacteroids.js
+++ b/src/Reacteroids.js
@@ -212,11 +212,12 @@ export class Reacteroids extends Component {
   checkCollision(obj1, obj2){
     var vx = obj1.position.x - obj2.position.x;
     var vy = obj1.position.y - obj2.position.y;
-    var length = Math.sqrt(vx * vx + vy * vy);
-    if(length < obj1.radius + obj2.radius){
-      return true;
-    }
-    return false;
+
+    // Keep the distance squared
+    // to avoid the expensive sqrt operation
+    var distanceSquared = vx * vx + vy * vy;
+
+    return distanceSquared <= Math.pow(obj1.radius + obj2.radius, 2);
   }
 
   render() {


### PR DESCRIPTION
All those Math.sqrt calls were probably adding up and taking unnecessary CPU cycles. So I did a minor refactor to help performance a little.